### PR TITLE
Layout Designer: canvas zoom and pan

### DIFF
--- a/docs/src/components/layout-designer/DesignerCanvas.vue
+++ b/docs/src/components/layout-designer/DesignerCanvas.vue
@@ -90,14 +90,21 @@ const panning = ref(false)
 let panLast: { x: number; y: number } | null = null
 
 function clampPan() {
-  // Keep at least 40px of the frame reachable inside the viewport so it can't be dragged away.
+  // Per axis, |pan| <= |frame - viewport| / 2. Frame bigger than the viewport: the frame must keep
+  // covering it (an edge can reach the viewport edge but never pass it, so no background gap while
+  // zoomed in — and when the viewport GROWS, the freed space reveals more of the clipped frame
+  // instead of moving it). Frame smaller: it stays fully inside the viewport.
   const r = viewport.value?.getBoundingClientRect()
   if (!r) return
-  const limX = r.width / 2 + (display.value.displayW * zoom.value) / 2 - 40
-  const limY = r.height / 2 + (display.value.displayH * zoom.value) / 2 - 40
+  const limX = Math.abs(display.value.displayW * zoom.value - r.width) / 2
+  const limY = Math.abs(display.value.displayH * zoom.value - r.height) / 2
   pan.x = Math.min(limX, Math.max(-limX, pan.x))
   pan.y = Math.min(limY, Math.max(-limY, pan.y))
 }
+
+// Re-clamp whenever the geometry changes under a fixed pan: pane resizes (dock splitters, window)
+// and zoom steps from the toolbar/keyboard (which don't know the viewport).
+watch([vw, vh, zoom], () => clampPan())
 
 useEventListener(
   viewport,
@@ -127,17 +134,13 @@ function isTyping(e: KeyboardEvent) {
   const t = e.target as HTMLElement | null
   return !!t && (t.tagName === 'INPUT' || t.tagName === 'SELECT' || t.tagName === 'TEXTAREA' || t.isContentEditable)
 }
+// Zoom keys live in the rebindable shortcut system (File > Settings; run from LayoutDesigner's
+// data-driven keydown handler) — only the Space pan chord is handled here.
 useEventListener(window, 'keydown', (e: KeyboardEvent) => {
   if (isTyping(e) || e.ctrlKey || e.metaKey || e.altKey) return
   if (e.key === ' ') {
     if ((e.target as HTMLElement)?.tagName !== 'BUTTON') e.preventDefault() // keep buttons space-clickable
     spaceHeld.value = true
-  } else if (e.key === '+' || e.key === '=') {
-    zoomAt(0, 0, 1.25)
-  } else if (e.key === '-' || e.key === '_') {
-    zoomAt(0, 0, 1 / 1.25)
-  } else if (e.key === '0') {
-    resetView()
   }
 })
 useEventListener(window, 'keyup', (e: KeyboardEvent) => {

--- a/docs/src/components/layout-designer/DesignerCanvas.vue
+++ b/docs/src/components/layout-designer/DesignerCanvas.vue
@@ -6,6 +6,7 @@ import ElementTypeMenu from './ElementTypeMenu.vue'
 import { canvasDisplay, canvasHeight, canvasWidth } from './geometry'
 import { useCanvasView } from './useCanvasView'
 import { useDesigner } from './useDesigner'
+import { isTypingTarget } from './useKeybinds'
 import { useScreenShare } from './useScreenShare'
 
 const { canvas, currentLayoutId, rootElements, select, selectedIds, rectOf, gridSize, guides, openContextMenu, addElement, addTextWithBackground } = useDesigner()
@@ -68,8 +69,11 @@ const effScale = computed(() => display.value.scale * zoom.value)
 // pane may zoom to a much higher relative % than a large one.
 watch(() => display.value.scale, (s) => (fitScale.value = s), { immediate: true })
 
-// Fresh layout, fresh view — a zoom made for one layout rarely fits another.
-watch(currentLayoutId, () => resetView())
+// Fresh layout, fresh view — a zoom made for one layout rarely fits another. Immediate so a
+// REMOUNT resets too: the view state is a module singleton but this watcher dies with the
+// component (the canvas is v-if'd away when no layout is open), so without it a layout opened
+// from the empty state would inherit whatever zoom/pan was left behind.
+watch(currentLayoutId, () => resetView(), { immediate: true })
 
 function cursorOffset(e: { clientX: number; clientY: number }): { x: number; y: number } {
   const r = viewport.value!.getBoundingClientRect()
@@ -79,6 +83,10 @@ function cursorOffset(e: { clientX: number; clientY: number }): { x: number; y: 
 // Wheel (plain or Ctrl — preventDefault also stops browser page-zoom on Ctrl) zooms about the
 // cursor. exp() gives smooth trackpad steps and ~16%/notch on a clicky wheel.
 function onWheel(e: WheelEvent) {
+  // No zooming mid-gesture: element drags divide their ACCUMULATED screen delta by the current
+  // scale and the marquee snapshots its rect at pointerdown — a scale change under a held button
+  // teleports the dragged element / breaks the marquee hit-test.
+  if (e.buttons !== 0) return
   const off = cursorOffset(e)
   zoomAt(off.x, off.y, Math.exp(-e.deltaY * 0.0015))
 }
@@ -93,18 +101,18 @@ function clampPan() {
   // Per axis, |pan| <= |frame - viewport| / 2. Frame bigger than the viewport: the frame must keep
   // covering it (an edge can reach the viewport edge but never pass it, so no background gap while
   // zoomed in — and when the viewport GROWS, the freed space reveals more of the clipped frame
-  // instead of moving it). Frame smaller: it stays fully inside the viewport.
-  const r = viewport.value?.getBoundingClientRect()
-  if (!r) return
-  const limX = Math.abs(display.value.displayW * zoom.value - r.width) / 2
-  const limY = Math.abs(display.value.displayH * zoom.value - r.height) / 2
+  // instead of moving it). Frame smaller: it stays fully inside the viewport. vw/vh are the
+  // reactive viewport size — no layout read on the per-pointermove path.
+  const limX = Math.abs(display.value.displayW * zoom.value - vw.value) / 2
+  const limY = Math.abs(display.value.displayH * zoom.value - vh.value) / 2
   pan.x = Math.min(limX, Math.max(-limX, pan.x))
   pan.y = Math.min(limY, Math.max(-limY, pan.y))
 }
 
-// Re-clamp whenever the geometry changes under a fixed pan: pane resizes (dock splitters, window)
-// and zoom steps from the toolbar/keyboard (which don't know the viewport).
-watch([vw, vh, zoom], () => clampPan())
+// Re-clamp whenever the geometry changes under a fixed pan: pane resizes (dock splitters, window),
+// zoom steps from the toolbar/keyboard (which don't know the viewport), and frame-size changes at
+// constant pane size (aspect preset switch — that's why `display` is watched, not just vw/vh).
+watch([vw, vh, zoom, display], () => clampPan())
 
 useEventListener(
   viewport,
@@ -118,28 +126,32 @@ useEventListener(
   },
   { capture: true },
 )
+function endPan() {
+  panLast = null
+  panning.value = false
+}
 useEventListener(window, 'pointermove', (e: PointerEvent) => {
   if (!panLast) return
+  // The ending pointerup can be lost (button released outside the window, pointercancel from a
+  // pen/OS gesture) — a move with no buttons held means the gesture is over, not still panning.
+  if (e.buttons === 0) return endPan()
   pan.x += e.clientX - panLast.x
   pan.y += e.clientY - panLast.y
   panLast = { x: e.clientX, y: e.clientY }
   clampPan()
 })
-useEventListener(window, 'pointerup', () => {
-  panLast = null
-  panning.value = false
-})
+useEventListener(window, 'pointerup', endPan)
+useEventListener(window, 'pointercancel', endPan)
 
-function isTyping(e: KeyboardEvent) {
-  const t = e.target as HTMLElement | null
-  return !!t && (t.tagName === 'INPUT' || t.tagName === 'SELECT' || t.tagName === 'TEXTAREA' || t.isContentEditable)
-}
 // Zoom keys live in the rebindable shortcut system (File > Settings; run from LayoutDesigner's
 // data-driven keydown handler) — only the Space pan chord is handled here.
 useEventListener(window, 'keydown', (e: KeyboardEvent) => {
-  if (isTyping(e) || e.ctrlKey || e.metaKey || e.altKey) return
+  if (isTypingTarget(e) || e.ctrlKey || e.metaKey || e.altKey) return
   if (e.key === ' ') {
-    if ((e.target as HTMLElement)?.tagName !== 'BUTTON') e.preventDefault() // keep buttons space-clickable
+    // A focused button owns Space (it activates on keyup) — engaging the pan chord too would both
+    // pan AND click the button when released. Leave the button its native behavior.
+    if ((e.target as HTMLElement)?.tagName === 'BUTTON') return
+    e.preventDefault()
     spaceHeld.value = true
   }
 })
@@ -149,15 +161,16 @@ useEventListener(window, 'keyup', (e: KeyboardEvent) => {
 // Alt-tabbing away mid-pan (or with Space held) never delivers the keyup/pointerup — reset.
 useEventListener(window, 'blur', () => {
   spaceHeld.value = false
-  panLast = null
-  panning.value = false
+  endPan()
 })
 
-// A press that starts a pan (MMB, or Space+left) must not clear the selection. Presses on frame
-// children are already intercepted by the capture-phase pan listener above; this guards presses
-// that land on the viewport background itself, where stopPropagation can't skip same-node listeners.
+// A press that starts a pan (MMB, or Space+left) must not clear the selection; every OTHER button
+// keeps the original clear-on-background behavior (right-click deselects before its context menu).
+// Presses on frame children are already intercepted by the capture-phase pan listener above; this
+// guards presses on the viewport background itself, where stopPropagation can't skip same-node
+// listeners.
 function onViewportPointerDown(e: PointerEvent) {
-  if (e.button !== 0 || spaceHeld.value) return
+  if (e.button === 1 || (e.button === 0 && spaceHeld.value)) return
   select(null)
 }
 
@@ -281,7 +294,7 @@ const hGuideStyle = computed(() => {
       <div v-if="vGuideStyle" class="ld-guide ld-guide-v" :style="vGuideStyle" />
       <div v-if="hGuideStyle" class="ld-guide ld-guide-h" :style="hGuideStyle" />
       <div v-if="bandStyle" class="ld-marquee" :style="bandStyle" />
-      <span class="ld-frame-label">{{ canvas.aspect }} · {{ Math.round(refW) }}×{{ Math.round(refH) }}<template v-if="zoom !== 1"> · {{ Math.round(zoom * 100) }}%</template></span>
+      <span class="ld-frame-label">{{ canvas.aspect }} · {{ Math.round(refW) }}×{{ Math.round(refH) }}<template v-if="Math.round(zoom * 100) !== 100"> · {{ Math.round(zoom * 100) }}%</template></span>
     </div>
   </div>
 </template>

--- a/docs/src/components/layout-designer/DesignerCanvas.vue
+++ b/docs/src/components/layout-designer/DesignerCanvas.vue
@@ -61,8 +61,12 @@ const display = computed(() => canvasDisplay(Math.max(0, vw.value - PAD * 2), Ma
 // The canvas scales arithmetically (children multiply CUI coords by `scale`), so zooming is just a
 // bigger frame + a bigger scale factor — selection handles, guide lines and the marquee stay
 // screen-size-constant because nothing is CSS-transform-scaled.
-const { zoom, pan, zoomAt, resetView } = useCanvasView()
+const { zoom, pan, fitScale, zoomAt, resetView } = useCanvasView()
 const effScale = computed(() => display.value.scale * zoom.value)
+
+// Feed the fit scale to the view state: the zoom ceiling is absolute magnification, so a small
+// pane may zoom to a much higher relative % than a large one.
+watch(() => display.value.scale, (s) => (fitScale.value = s), { immediate: true })
 
 // Fresh layout, fresh view — a zoom made for one layout rarely fits another.
 watch(currentLayoutId, () => resetView())

--- a/docs/src/components/layout-designer/DesignerCanvas.vue
+++ b/docs/src/components/layout-designer/DesignerCanvas.vue
@@ -4,10 +4,11 @@ import { computed, ref, watch } from 'vue'
 import CanvasElement from './CanvasElement.vue'
 import ElementTypeMenu from './ElementTypeMenu.vue'
 import { canvasDisplay, canvasHeight, canvasWidth } from './geometry'
+import { useCanvasView } from './useCanvasView'
 import { useDesigner } from './useDesigner'
 import { useScreenShare } from './useScreenShare'
 
-const { canvas, rootElements, select, selectedIds, rectOf, gridSize, guides, openContextMenu, addElement, addTextWithBackground } = useDesigner()
+const { canvas, currentLayoutId, rootElements, select, selectedIds, rectOf, gridSize, guides, openContextMenu, addElement, addTextWithBackground } = useDesigner()
 
 // Empty-canvas CTA: a centered, outline-styled "Add an element" that opens the type picker.
 const emptyMenuOpen = ref(false)
@@ -56,9 +57,107 @@ const refW = computed(() => canvasWidth(canvas))
 const refH = computed(() => canvasHeight(canvas))
 const display = computed(() => canvasDisplay(Math.max(0, vw.value - PAD * 2), Math.max(0, vh.value - PAD * 2), canvas))
 
+// --- zoom + pan (view state only — never persisted, never in exports) -----------------
+// The canvas scales arithmetically (children multiply CUI coords by `scale`), so zooming is just a
+// bigger frame + a bigger scale factor — selection handles, guide lines and the marquee stay
+// screen-size-constant because nothing is CSS-transform-scaled.
+const { zoom, pan, zoomAt, resetView } = useCanvasView()
+const effScale = computed(() => display.value.scale * zoom.value)
+
+// Fresh layout, fresh view — a zoom made for one layout rarely fits another.
+watch(currentLayoutId, () => resetView())
+
+function cursorOffset(e: { clientX: number; clientY: number }): { x: number; y: number } {
+  const r = viewport.value!.getBoundingClientRect()
+  return { x: e.clientX - (r.left + r.width / 2), y: e.clientY - (r.top + r.height / 2) }
+}
+
+// Wheel (plain or Ctrl — preventDefault also stops browser page-zoom on Ctrl) zooms about the
+// cursor. exp() gives smooth trackpad steps and ~16%/notch on a clicky wheel.
+function onWheel(e: WheelEvent) {
+  const off = cursorOffset(e)
+  zoomAt(off.x, off.y, Math.exp(-e.deltaY * 0.0015))
+}
+
+// MMB drag (or Space + left-drag) pans. Intercepted capture-phase on the viewport so it wins over
+// marquee/element drags without touching their handlers.
+const spaceHeld = ref(false)
+const panning = ref(false)
+let panLast: { x: number; y: number } | null = null
+
+function clampPan() {
+  // Keep at least 40px of the frame reachable inside the viewport so it can't be dragged away.
+  const r = viewport.value?.getBoundingClientRect()
+  if (!r) return
+  const limX = r.width / 2 + (display.value.displayW * zoom.value) / 2 - 40
+  const limY = r.height / 2 + (display.value.displayH * zoom.value) / 2 - 40
+  pan.x = Math.min(limX, Math.max(-limX, pan.x))
+  pan.y = Math.min(limY, Math.max(-limY, pan.y))
+}
+
+useEventListener(
+  viewport,
+  'pointerdown',
+  (e: PointerEvent) => {
+    if (e.button !== 1 && !(e.button === 0 && spaceHeld.value)) return
+    e.preventDefault() // middle button: no autoscroll
+    e.stopPropagation()
+    panLast = { x: e.clientX, y: e.clientY }
+    panning.value = true
+  },
+  { capture: true },
+)
+useEventListener(window, 'pointermove', (e: PointerEvent) => {
+  if (!panLast) return
+  pan.x += e.clientX - panLast.x
+  pan.y += e.clientY - panLast.y
+  panLast = { x: e.clientX, y: e.clientY }
+  clampPan()
+})
+useEventListener(window, 'pointerup', () => {
+  panLast = null
+  panning.value = false
+})
+
+function isTyping(e: KeyboardEvent) {
+  const t = e.target as HTMLElement | null
+  return !!t && (t.tagName === 'INPUT' || t.tagName === 'SELECT' || t.tagName === 'TEXTAREA' || t.isContentEditable)
+}
+useEventListener(window, 'keydown', (e: KeyboardEvent) => {
+  if (isTyping(e) || e.ctrlKey || e.metaKey || e.altKey) return
+  if (e.key === ' ') {
+    if ((e.target as HTMLElement)?.tagName !== 'BUTTON') e.preventDefault() // keep buttons space-clickable
+    spaceHeld.value = true
+  } else if (e.key === '+' || e.key === '=') {
+    zoomAt(0, 0, 1.25)
+  } else if (e.key === '-' || e.key === '_') {
+    zoomAt(0, 0, 1 / 1.25)
+  } else if (e.key === '0') {
+    resetView()
+  }
+})
+useEventListener(window, 'keyup', (e: KeyboardEvent) => {
+  if (e.key === ' ') spaceHeld.value = false
+})
+// Alt-tabbing away mid-pan (or with Space held) never delivers the keyup/pointerup — reset.
+useEventListener(window, 'blur', () => {
+  spaceHeld.value = false
+  panLast = null
+  panning.value = false
+})
+
+// A press that starts a pan (MMB, or Space+left) must not clear the selection. Presses on frame
+// children are already intercepted by the capture-phase pan listener above; this guards presses
+// that land on the viewport background itself, where stopPropagation can't skip same-node listeners.
+function onViewportPointerDown(e: PointerEvent) {
+  if (e.button !== 0 || spaceHeld.value) return
+  select(null)
+}
+
 const frameStyle = computed(() => ({
-  width: `${display.value.displayW}px`,
-  height: `${display.value.displayH}px`,
+  width: `${display.value.displayW * zoom.value}px`,
+  height: `${display.value.displayH * zoom.value}px`,
+  transform: `translate(${pan.x}px, ${pan.y}px)`,
   // drives the design-overlay fade in CanvasElement (#7); 1 = fully opaque (normal). Only fades while the
   // backdrop is actually showing — stopping the share or unchecking "show behind canvas" snaps the design
   // back to full opacity (so you can't strand a blank layout), while the slider keeps its value for reuse.
@@ -67,7 +166,7 @@ const frameStyle = computed(() => ({
 
 // Visible grid reflects the snap grid size; hidden when too fine to be useful.
 const gridStyle = computed(() => {
-  const px = gridSize.value * display.value.scale
+  const px = gridSize.value * effScale.value
   if (px < 6) return { display: 'none' }
   return { backgroundSize: `${px}px ${px}px, ${px}px ${px}px` }
 })
@@ -113,7 +212,7 @@ useEventListener(window, 'pointerup', () => {
   if (!b) {
     if (!bandStart.shift) select(null) // bare click on empty canvas clears (Shift-click keeps) selection
   } else {
-    const s = display.value.scale
+    const s = effScale.value
     const mx0 = Math.min(b.x0, b.x1)
     const mx1 = Math.max(b.x0, b.x1)
     const my0 = Math.min(b.y0, b.y1)
@@ -136,19 +235,26 @@ useEventListener(window, 'pointerup', () => {
 const vGuideStyle = computed(() => {
   const g = guides.v
   if (!g) return null
-  const s = display.value.scale
+  const s = effScale.value
   return { left: `${g.x * s}px`, top: `${(refH.value - g.y1) * s}px`, height: `${(g.y1 - g.y0) * s}px` }
 })
 const hGuideStyle = computed(() => {
   const g = guides.h
   if (!g) return null
-  const s = display.value.scale
+  const s = effScale.value
   return { top: `${(refH.value - g.y) * s}px`, left: `${g.x0 * s}px`, width: `${(g.x1 - g.x0) * s}px` }
 })
 </script>
 
 <template>
-  <div ref="viewport" class="ld-viewport" @pointerdown="select(null)" @contextmenu.prevent="openContextMenu(null, $event.clientX, $event.clientY)">
+  <div
+    ref="viewport"
+    class="ld-viewport"
+    :class="{ 'ld-pan-ready': spaceHeld && !panning, 'ld-panning': panning }"
+    @pointerdown="onViewportPointerDown"
+    @wheel.prevent="onWheel"
+    @contextmenu.prevent="openContextMenu(null, $event.clientX, $event.clientY)"
+  >
     <div ref="frame" class="ld-frame" :style="frameStyle" @pointerdown.stop="onFramePointerDown">
       <div v-if="!rootElements.length" class="ld-empty-cta" @pointerdown.stop>
         <button class="ld-empty-add" @click.stop="emptyMenuOpen = !emptyMenuOpen">+ Add an element</button>
@@ -163,12 +269,12 @@ const hGuideStyle = computed(() => {
         :element="el"
         :parent-w="refW"
         :parent-h="refH"
-        :scale="display.scale"
+        :scale="effScale"
       />
       <div v-if="vGuideStyle" class="ld-guide ld-guide-v" :style="vGuideStyle" />
       <div v-if="hGuideStyle" class="ld-guide ld-guide-h" :style="hGuideStyle" />
       <div v-if="bandStyle" class="ld-marquee" :style="bandStyle" />
-      <span class="ld-frame-label">{{ canvas.aspect }} · {{ Math.round(refW) }}×{{ Math.round(refH) }}</span>
+      <span class="ld-frame-label">{{ canvas.aspect }} · {{ Math.round(refW) }}×{{ Math.round(refH) }}<template v-if="zoom !== 1"> · {{ Math.round(zoom * 100) }}%</template></span>
     </div>
   </div>
 </template>
@@ -210,6 +316,16 @@ const hGuideStyle = computed(() => {
   isolation: isolate;
   background:
     repeating-conic-gradient(rgba(255, 255, 255, 0.018) 0% 25%, transparent 0% 50%) 50% / 24px 24px;
+}
+
+/* Space held / dragging with MMB — the whole viewport becomes a pan surface */
+.ld-viewport.ld-pan-ready,
+.ld-viewport.ld-pan-ready * {
+  cursor: grab !important;
+}
+.ld-viewport.ld-panning,
+.ld-viewport.ld-panning * {
+  cursor: grabbing !important;
 }
 
 .ld-frame {

--- a/docs/src/components/layout-designer/DesignerCanvas.vue
+++ b/docs/src/components/layout-designer/DesignerCanvas.vue
@@ -330,6 +330,10 @@ const hGuideStyle = computed(() => {
 
 .ld-frame {
   position: relative;
+  /* the frame is a flex item — without this, a zoomed width wider than the viewport gets
+     flex-shrunk while the arithmetic content keeps its full size, clipping it off the right
+     and breaking the frame's aspect */
+  flex-shrink: 0;
   background: #0c0c0e;
   box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.14), 0 16px 48px rgba(0, 0, 0, 0.5);
   overflow: hidden;

--- a/docs/src/components/layout-designer/LayoutDesigner.vue
+++ b/docs/src/components/layout-designer/LayoutDesigner.vue
@@ -11,9 +11,9 @@ import LayoutSettingsModal from './LayoutSettingsModal.vue'
 import LivePreviewControls from './LivePreviewControls.vue'
 import { PANE_TITLES, leavesOf, locate, type DockSide, type PaneId } from './dockTree'
 import { ASPECT_PRESETS, CLIENT_PANELS, type AspectPreset, type ClientPanel, type LayoutPreset } from './types'
-import { useCanvasView } from './useCanvasView'
+import { ZOOM_STEP, useCanvasView } from './useCanvasView'
 import { useDesigner } from './useDesigner'
-import { comboFromEvent, comboLabel, useKeybinds, type KeyActionId } from './useKeybinds'
+import { comboFromEvent, comboLabel, isTypingTarget, useKeybinds, type KeyActionId } from './useKeybinds'
 import { useDock } from './useDock'
 import { useScreenShare } from './useScreenShare'
 import { useDockDrag } from './useDockDrag'
@@ -164,10 +164,6 @@ function doMoveToFolder(id: string, current?: string) {
 }
 
 // --- keyboard shortcuts ---
-function isTyping(e: KeyboardEvent) {
-  const t = e.target as HTMLElement | null
-  return !!t && (t.tagName === 'INPUT' || t.tagName === 'SELECT' || t.tagName === 'TEXTAREA' || t.isContentEditable)
-}
 // Shortcuts are data-driven (Settings → Keyboard shortcuts can rebind them); arrow-nudge stays fixed.
 const { actionForCombo, bindingFor } = useKeybinds()
 function runKeyAction(id: KeyActionId) {
@@ -177,12 +173,12 @@ function runKeyAction(id: KeyActionId) {
   else if (id === 'group') groupSelection()
   else if (id === 'ungroup') ungroupSelection()
   else if (id === 'delete') removeSelected()
-  else if (id === 'zoomIn') canvasZoomAt(0, 0, 1.25)
-  else if (id === 'zoomOut') canvasZoomAt(0, 0, 1 / 1.25)
+  else if (id === 'zoomIn') canvasZoomAt(0, 0, ZOOM_STEP)
+  else if (id === 'zoomOut') canvasZoomAt(0, 0, 1 / ZOOM_STEP)
   else if (id === 'zoomReset') canvasResetView()
 }
 useEventListener(window, 'keydown', (e: KeyboardEvent) => {
-  if (isTyping(e)) return
+  if (isTypingTarget(e)) return
   const action = actionForCombo(comboFromEvent(e))
   if (action) {
     if (action === 'delete' && !selectedIds.value.length) return
@@ -444,9 +440,9 @@ const { dragging: dockDragging, pointer: dockPointer } = useDockDrag()
 
       <div v-if="tbShown('zoom')" class="ld-tool-field">
         <span>Zoom</span>
-        <button class="ld-icon-btn" :title="`Zoom out (${comboLabel(bindingFor('zoomOut'))})`" @click="canvasZoomAt(0, 0, 1 / 1.25)"><ZoomOut :size="15" /></button>
-        <button class="ld-zoom-pct" :class="{ zoomed: canvasZoom !== 1 }" :title="`Reset zoom to fit (${comboLabel(bindingFor('zoomReset'))})`" @click="canvasResetView()">{{ Math.round(canvasZoom * 100) }}%</button>
-        <button class="ld-icon-btn" :title="`Zoom in (${comboLabel(bindingFor('zoomIn'))})`" @click="canvasZoomAt(0, 0, 1.25)"><ZoomIn :size="15" /></button>
+        <button class="ld-icon-btn" :title="`Zoom out (${comboLabel(bindingFor('zoomOut'))})`" @click="runKeyAction('zoomOut')"><ZoomOut :size="15" /></button>
+        <button class="ld-zoom-pct" :class="{ zoomed: Math.round(canvasZoom * 100) !== 100 }" :title="`Reset zoom to fit (${comboLabel(bindingFor('zoomReset'))})`" @click="runKeyAction('zoomReset')">{{ Math.round(canvasZoom * 100) }}%</button>
+        <button class="ld-icon-btn" :title="`Zoom in (${comboLabel(bindingFor('zoomIn'))})`" @click="runKeyAction('zoomIn')"><ZoomIn :size="15" /></button>
         <InfoTip text="Canvas zoom — view only, never part of the layout or the generated code. Mouse wheel over the canvas zooms at the cursor; middle-mouse (or Space) drag pans; zoom keys are rebindable in File > Settings. Click the percentage to reset to fit." />
       </div>
 

--- a/docs/src/components/layout-designer/LayoutDesigner.vue
+++ b/docs/src/components/layout-designer/LayoutDesigner.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import './fonts/index.css' // self-hosted Rust CUI fonts; here so they load on the tool page only
 import { useEventListener, useStorage } from '@vueuse/core'
-import { Check, ChevronRight, Clipboard, ClipboardPaste, Folder, FolderInput, FolderOpen, Lock, Pencil, Plus, Redo2, RotateCcw, Settings, Shapes, Trash2, Undo2, X } from 'lucide-vue-next'
+import { Check, ChevronRight, Clipboard, ClipboardPaste, Folder, FolderInput, FolderOpen, Lock, Pencil, Plus, Redo2, RotateCcw, Settings, Shapes, Trash2, Undo2, X, ZoomIn, ZoomOut } from 'lucide-vue-next'
 import { computed, onBeforeUnmount, onMounted, provide, ref } from 'vue'
 import ContextMenu from './ContextMenu.vue'
 import DockNode from './DockNode.vue'
@@ -11,6 +11,7 @@ import LayoutSettingsModal from './LayoutSettingsModal.vue'
 import LivePreviewControls from './LivePreviewControls.vue'
 import { PANE_TITLES, leavesOf, locate, type DockSide, type PaneId } from './dockTree'
 import { ASPECT_PRESETS, CLIENT_PANELS, type AspectPreset, type ClientPanel, type LayoutPreset } from './types'
+import { useCanvasView } from './useCanvasView'
 import { useDesigner } from './useDesigner'
 import { comboFromEvent, useKeybinds, type KeyActionId } from './useKeybinds'
 import { useDock } from './useDock'
@@ -237,10 +238,14 @@ const tbToggle = (key: string) => (toolbarStore.value = { ...(toolbarStore.value
 const TOOLBAR_TOGGLES = [
   { key: 'history', label: 'Undo / Redo' },
   { key: 'aspect', label: 'Aspect' },
+  { key: 'zoom', label: 'Zoom' },
   { key: 'layer', label: 'Layer' },
   { key: 'grid', label: 'Grid' },
   { key: 'bounds', label: 'Bounds' },
 ]
+
+// Canvas zoom (the canvas owns wheel/MMB/Space interactions; these are the toolbar controls)
+const { zoom: canvasZoom, zoomAt: canvasZoomAt, resetView: canvasResetView } = useCanvasView()
 
 // Last spot each hidden pane occupied, so re-showing lands it back where it was. Persisted so it
 // survives reloads; falls back to a sensible default home when the remembered neighbour is gone.
@@ -434,6 +439,14 @@ const { dragging: dockDragging, pointer: dockPointer } = useDockDrag()
       </div>
 
 
+      <div v-if="tbShown('zoom')" class="ld-tool-field">
+        <span>Zoom</span>
+        <button class="ld-icon-btn" title="Zoom out (-)" @click="canvasZoomAt(0, 0, 1 / 1.25)"><ZoomOut :size="15" /></button>
+        <button class="ld-zoom-pct" :class="{ zoomed: canvasZoom !== 1 }" title="Reset zoom to fit (0)" @click="canvasResetView()">{{ Math.round(canvasZoom * 100) }}%</button>
+        <button class="ld-icon-btn" title="Zoom in (+)" @click="canvasZoomAt(0, 0, 1.25)"><ZoomIn :size="15" /></button>
+        <InfoTip text="Canvas zoom — view only, never part of the layout or the generated code. Mouse wheel over the canvas zooms at the cursor; middle-mouse (or Space) drag pans; keyboard + / - / 0. Click the percentage to reset to fit." />
+      </div>
+
       <label v-if="tbShown('layer')" class="ld-tool-field">
         <span>Layer</span>
         <select
@@ -581,6 +594,27 @@ const { dragging: dockDragging, pointer: dockPointer } = useDockDrag()
 .ld-icon-btn:disabled {
   opacity: 0.35;
   cursor: default;
+}
+
+/* zoom percentage readout — click resets to fit */
+.ld-zoom-pct {
+  min-width: 44px;
+  height: 30px;
+  padding: 0 4px;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 4px;
+  color: var(--vp-c-text-2);
+}
+
+.ld-zoom-pct:hover {
+  border-color: var(--c-carbon-1);
+  color: var(--vp-c-text-1);
+}
+
+.ld-zoom-pct.zoomed {
+  color: var(--c-carbon-1);
 }
 
 /* dropdown menus (layouts) */

--- a/docs/src/components/layout-designer/LayoutDesigner.vue
+++ b/docs/src/components/layout-designer/LayoutDesigner.vue
@@ -13,7 +13,7 @@ import { PANE_TITLES, leavesOf, locate, type DockSide, type PaneId } from './doc
 import { ASPECT_PRESETS, CLIENT_PANELS, type AspectPreset, type ClientPanel, type LayoutPreset } from './types'
 import { useCanvasView } from './useCanvasView'
 import { useDesigner } from './useDesigner'
-import { comboFromEvent, useKeybinds, type KeyActionId } from './useKeybinds'
+import { comboFromEvent, comboLabel, useKeybinds, type KeyActionId } from './useKeybinds'
 import { useDock } from './useDock'
 import { useScreenShare } from './useScreenShare'
 import { useDockDrag } from './useDockDrag'
@@ -169,7 +169,7 @@ function isTyping(e: KeyboardEvent) {
   return !!t && (t.tagName === 'INPUT' || t.tagName === 'SELECT' || t.tagName === 'TEXTAREA' || t.isContentEditable)
 }
 // Shortcuts are data-driven (Settings → Keyboard shortcuts can rebind them); arrow-nudge stays fixed.
-const { actionForCombo } = useKeybinds()
+const { actionForCombo, bindingFor } = useKeybinds()
 function runKeyAction(id: KeyActionId) {
   if (id === 'undo') undo()
   else if (id === 'redo') redo()
@@ -177,6 +177,9 @@ function runKeyAction(id: KeyActionId) {
   else if (id === 'group') groupSelection()
   else if (id === 'ungroup') ungroupSelection()
   else if (id === 'delete') removeSelected()
+  else if (id === 'zoomIn') canvasZoomAt(0, 0, 1.25)
+  else if (id === 'zoomOut') canvasZoomAt(0, 0, 1 / 1.25)
+  else if (id === 'zoomReset') canvasResetView()
 }
 useEventListener(window, 'keydown', (e: KeyboardEvent) => {
   if (isTyping(e)) return
@@ -441,10 +444,10 @@ const { dragging: dockDragging, pointer: dockPointer } = useDockDrag()
 
       <div v-if="tbShown('zoom')" class="ld-tool-field">
         <span>Zoom</span>
-        <button class="ld-icon-btn" title="Zoom out (-)" @click="canvasZoomAt(0, 0, 1 / 1.25)"><ZoomOut :size="15" /></button>
-        <button class="ld-zoom-pct" :class="{ zoomed: canvasZoom !== 1 }" title="Reset zoom to fit (0)" @click="canvasResetView()">{{ Math.round(canvasZoom * 100) }}%</button>
-        <button class="ld-icon-btn" title="Zoom in (+)" @click="canvasZoomAt(0, 0, 1.25)"><ZoomIn :size="15" /></button>
-        <InfoTip text="Canvas zoom — view only, never part of the layout or the generated code. Mouse wheel over the canvas zooms at the cursor; middle-mouse (or Space) drag pans; keyboard + / - / 0. Click the percentage to reset to fit." />
+        <button class="ld-icon-btn" :title="`Zoom out (${comboLabel(bindingFor('zoomOut'))})`" @click="canvasZoomAt(0, 0, 1 / 1.25)"><ZoomOut :size="15" /></button>
+        <button class="ld-zoom-pct" :class="{ zoomed: canvasZoom !== 1 }" :title="`Reset zoom to fit (${comboLabel(bindingFor('zoomReset'))})`" @click="canvasResetView()">{{ Math.round(canvasZoom * 100) }}%</button>
+        <button class="ld-icon-btn" :title="`Zoom in (${comboLabel(bindingFor('zoomIn'))})`" @click="canvasZoomAt(0, 0, 1.25)"><ZoomIn :size="15" /></button>
+        <InfoTip text="Canvas zoom — view only, never part of the layout or the generated code. Mouse wheel over the canvas zooms at the cursor; middle-mouse (or Space) drag pans; zoom keys are rebindable in File > Settings. Click the percentage to reset to fit." />
       </div>
 
       <label v-if="tbShown('layer')" class="ld-tool-field">

--- a/docs/src/components/layout-designer/useCanvasView.ts
+++ b/docs/src/components/layout-designer/useCanvasView.ts
@@ -6,12 +6,21 @@ import { reactive, ref } from 'vue'
 
 export const ZOOM_MIN = 0.25
 export const ZOOM_MAX = 8
+/** Absolute magnification ceiling: screen px per CUI reference px. `zoom` is relative to the
+ *  fit-to-pane scale, so a small pane fits at a small scale — capping only the relative zoom
+ *  would cap a small window at a uselessly low magnification (1px gridlines never even show). */
+const MAX_EFF_SCALE = 10
+
+/** The current fit-to-pane scale (screen px per reference px at zoom 1) — kept up to date by the
+ *  canvas so the zoom ceiling can be expressed in absolute magnification. */
+const fitScale = ref(1)
 
 const zoom = ref(1)
 const pan = reactive({ x: 0, y: 0 })
 
 function clampZoom(z: number): number {
-  return Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, z))
+  const max = Math.max(ZOOM_MAX, MAX_EFF_SCALE / Math.max(0.01, fitScale.value))
+  return Math.min(max, Math.max(ZOOM_MIN, z))
 }
 
 /** Back to fit-to-pane, centered. */
@@ -37,5 +46,5 @@ function zoomAt(offX: number, offY: number, factor: number) {
 }
 
 export function useCanvasView() {
-  return { zoom, pan, zoomAt, resetView }
+  return { zoom, pan, fitScale, zoomAt, resetView }
 }

--- a/docs/src/components/layout-designer/useCanvasView.ts
+++ b/docs/src/components/layout-designer/useCanvasView.ts
@@ -1,0 +1,41 @@
+// Canvas view state — zoom + pan, shared by the canvas (wheel/drag/keys) and the toolbar zoom
+// controls. Pure view state: never persisted, never part of undo history, layouts or exports.
+// `zoom` multiplies the fit-to-pane scale (1 = fit); `pan` is the frame's screen-px offset from
+// its flex-centered position.
+import { reactive, ref } from 'vue'
+
+export const ZOOM_MIN = 0.25
+export const ZOOM_MAX = 8
+
+const zoom = ref(1)
+const pan = reactive({ x: 0, y: 0 })
+
+function clampZoom(z: number): number {
+  return Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, z))
+}
+
+/** Back to fit-to-pane, centered. */
+function resetView() {
+  zoom.value = 1
+  pan.x = 0
+  pan.y = 0
+}
+
+/**
+ * Zoom about a fixed screen point given as an offset from the viewport centre (0,0 = centre —
+ * used by the toolbar/keyboard; the wheel handler passes the cursor offset). Scaling the pan by
+ * the zoom ratio keeps that point over the same layout spot, so the frame can never zoom itself
+ * out of view.
+ */
+function zoomAt(offX: number, offY: number, factor: number) {
+  const z1 = clampZoom(zoom.value * factor)
+  const k = z1 / zoom.value
+  if (k === 1) return
+  pan.x = k * pan.x + (1 - k) * offX
+  pan.y = k * pan.y + (1 - k) * offY
+  zoom.value = z1
+}
+
+export function useCanvasView() {
+  return { zoom, pan, zoomAt, resetView }
+}

--- a/docs/src/components/layout-designer/useCanvasView.ts
+++ b/docs/src/components/layout-designer/useCanvasView.ts
@@ -6,6 +6,8 @@ import { reactive, ref } from 'vue'
 
 export const ZOOM_MIN = 0.25
 export const ZOOM_MAX = 8
+/** Step for one discrete zoom action (toolbar buttons, keyboard) — single source of truth. */
+export const ZOOM_STEP = 1.25
 /** Absolute magnification ceiling: screen px per CUI reference px. `zoom` is relative to the
  *  fit-to-pane scale, so a small pane fits at a small scale — capping only the relative zoom
  *  would cap a small window at a uselessly low magnification (1px gridlines never even show). */

--- a/docs/src/components/layout-designer/useKeybinds.ts
+++ b/docs/src/components/layout-designer/useKeybinds.ts
@@ -34,12 +34,23 @@ export function comboFromEvent(e: KeyboardEvent): string {
   if (k === 'control' || k === 'meta' || k === 'shift' || k === 'alt') return ''
   if (k === ' ') k = 'space'
   if (k === 'backspace') k = 'delete' // treat Backspace as Delete
+  if (k === '+') k = '=' // '+' is Shift+'=' / numpad plus — fold onto the zoom-in default
+  if (k === '_') k = '-'
   const parts: string[] = []
   if (e.ctrlKey || e.metaKey) parts.push('mod')
-  if (e.shiftKey) parts.push('shift')
+  // For printable non-letter keys, e.key already reflects the shift layer (Shift+'=' is '+',
+  // AZERTY digits NEED Shift) — including 'shift' would double-count it and make such defaults
+  // unmatchable on some layouts. Letters keep it (shift+z vs z is a real distinction).
+  if (e.shiftKey && !(k.length === 1 && !/[a-z]/.test(k))) parts.push('shift')
   if (e.altKey) parts.push('alt')
   parts.push(k)
   return parts.join('+')
+}
+
+/** True when the event targets an editable control — shared guard for global key handlers. */
+export function isTypingTarget(e: KeyboardEvent): boolean {
+  const t = e.target as HTMLElement | null
+  return !!t && (t.tagName === 'INPUT' || t.tagName === 'SELECT' || t.tagName === 'TEXTAREA' || t.isContentEditable)
 }
 
 /** Human-readable combo, e.g. "Ctrl+Shift+Z" / "Delete". */

--- a/docs/src/components/layout-designer/useKeybinds.ts
+++ b/docs/src/components/layout-designer/useKeybinds.ts
@@ -3,7 +3,7 @@
 // action via `actionForCombo`, and the Settings modal edits bindings via `setBinding`/`resetBinding`.
 import { useStorage } from '@vueuse/core'
 
-export type KeyActionId = 'undo' | 'redo' | 'duplicate' | 'group' | 'ungroup' | 'delete'
+export type KeyActionId = 'undo' | 'redo' | 'duplicate' | 'group' | 'ungroup' | 'delete' | 'zoomIn' | 'zoomOut' | 'zoomReset'
 
 export interface KeyAction {
   id: KeyActionId
@@ -19,6 +19,10 @@ export const KEY_ACTIONS: KeyAction[] = [
   { id: 'group', label: 'Group selection', default: 'mod+g' },
   { id: 'ungroup', label: 'Ungroup selection', default: 'mod+shift+g' },
   { id: 'delete', label: 'Delete selection', default: 'delete' },
+  // '=' is the unshifted key under '+' on common layouts (numpad '+' can be rebound to combo "+").
+  { id: 'zoomIn', label: 'Zoom in', default: '=' },
+  { id: 'zoomOut', label: 'Zoom out', default: '-' },
+  { id: 'zoomReset', label: 'Zoom reset (fit)', default: '0' },
 ]
 
 // id → combo override. Absent ⇒ the action's default. Module singleton so handler + modal share it.


### PR DESCRIPTION
Add ability to zoom in/out of layout designer and drag the canvas around using mmb by default (new controls added to settings). Zoom toolbar included with view to toggle visibility.